### PR TITLE
Rebrand platform to SANDOVAL AI and update ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Legislatech AI
+# SANDOVAL AI
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -7,11 +7,11 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13+-blue.svg)](https://www.postgresql.org/)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://www.docker.com/)
 
-> **Repositório oficial do [https://legisla.tech/ai](https://legisla.tech/ai)** - Plataforma de IA para análise inteligente da legislação brasileira
+> **Repositório oficial do [https://sandoval.ai](https://sandoval.ai)** - Plataforma de IA para análise inteligente da legislação brasileira desenvolvida pela **AASN**
 
 ## 📖 Sobre o Projeto
 
-O **Legislatech AI** é uma plataforma de inteligência artificial especializada em análise e busca de legislação brasileira. Utilizando tecnologias avançadas de processamento de linguagem natural e machine learning, oferecemos soluções inteligentes para navegar, compreender e extrair insights da complexa legislação brasileira.
+O **SANDOVAL AI** é uma plataforma de inteligência artificial especializada em análise e busca de legislação brasileira. Utilizando tecnologias avançadas de processamento de linguagem natural e machine learning, oferecemos soluções inteligentes para navegar, compreender e extrair insights da complexa legislação brasileira.
 
 ### 🎯 Objetivos
 
@@ -34,8 +34,8 @@ O **Legislatech AI** é uma plataforma de inteligência artificial especializada
 O projeto está organizado em módulos especializados com arquitetura moderna:
 
 ```
-legislatech-ai/
-├── legislatech-ai-api/     # API REST com FastAPI
+sandoval-ai/
+├── sandoval-ai-api/     # API REST com FastAPI
 │   ├── routes/            # Endpoints organizados por versão
 │   │   ├── v1.py         # RAG Search com reranking
 │   │   ├── v2.py         # Intent Router
@@ -70,13 +70,13 @@ legislatech-ai/
 
 1. **Clone o repositório**
    ```bash
-   git clone https://github.com/seu-usuario/legislatech-ai.git
-   cd legislatech-ai
+   git clone https://github.com/seu-usuario/sandoval-ai.git
+   cd sandoval-ai
    ```
 
 2. **Configure a API**
    ```bash
-   cd legislatech-ai-api
+   cd sandoval-ai-api
    python -m venv venv
    source venv/bin/activate  # Linux/Mac
    # ou venv\Scripts\activate  # Windows
@@ -92,16 +92,16 @@ legislatech-ai/
 
 4. **Execute a aplicação**
    ```bash
-   uvicorn main:app --reload --host 0.0.0.0 --port 8000
+   uvicorn main:app --reload --host 0.0.0.0 --port 68000
    ```
 
 #### Opção 2: Com Docker
 
 ```bash
-git clone https://github.com/seu-usuario/legislatech-ai.git
-cd legislatech-ai/legislatech-ai-api
-docker build -t legislatech-ai .
-docker run -p 8000:8000 --env-file .env legislatech-ai
+git clone https://github.com/seu-usuario/sandoval-ai.git
+cd sandoval-ai/sandoval-ai-api
+docker build -t sandoval-ai .
+docker run -p 68000:68000 --env-file .env sandoval-ai
 ```
 
 ### 🔧 Configuração do Banco de Dados
@@ -120,20 +120,20 @@ docker run -p 8000:8000 --env-file .env legislatech-ai
 2. **Configure a extensão**
    ```sql
    CREATE EXTENSION IF NOT EXISTS vector;
-   CREATE DATABASE legislatech;
+   CREATE DATABASE sandoval;
    ```
 
 3. **Configure a string de conexão**
    ```env
-   POSTGRES_CONNECTION_STRING=postgresql://usuario:senha@localhost:5432/legislatech
+   POSTGRES_CONNECTION_STRING=postgresql://usuario:senha@localhost:65432/sandoval
    ```
 
 ### 📚 Documentação Interativa
 
 Após iniciar a aplicação, acesse:
-- **Swagger UI**: http://localhost:8000/docs
-- **ReDoc**: http://localhost:8000/redoc
-- **OpenAPI JSON**: http://localhost:8000/openapi.json
+- **Swagger UI**: http://localhost:68000/docs
+- **ReDoc**: http://localhost:68000/redoc
+- **OpenAPI JSON**: http://localhost:68000/openapi.json
 
 ## 🔧 Tecnologias Utilizadas
 
@@ -172,7 +172,7 @@ Após iniciar a aplicação, acesse:
 - **Cache otimizado** para performance
 
 ```bash
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'usuario:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{"input": [{"role": "user", "content": [{"type": "text", "text": "Quais são os direitos do trabalhador em caso de acidente de trabalho?"}]}]}'
@@ -197,7 +197,7 @@ curl -X POST "http://localhost:8000/v1/responses" \
 - **Visualização de relacionamentos**
 
 ```bash
-curl -X GET "http://localhost:8000/grafo/" \
+curl -X GET "http://localhost:68000/grafo/" \
      -H "Authorization: Basic $(echo -n 'usuario:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{
@@ -234,7 +234,7 @@ curl -X GET "http://localhost:8000/grafo/" \
 A API utiliza autenticação HTTP Basic para endpoints sensíveis:
 
 ```bash
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'usuario:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{"input": [{"role": "user", "content": [{"type": "text", "text": "teste"}]}]}'
@@ -249,7 +249,7 @@ import requests
 import base64
 
 # Busca sobre direitos trabalhistas
-response = requests.post("http://localhost:8000/v1/responses", 
+response = requests.post("http://localhost:68000/v1/responses", 
     headers={
         "Authorization": "Basic " + base64.b64encode(b"admin:senha").decode(),
         "Content-Type": "application/json"
@@ -276,7 +276,7 @@ print(response.text)  # Resposta em formato SSE
 
 ```python
 # Análise de grafo de uma lei específica
-response = requests.get("http://localhost:8000/grafo/", params={
+response = requests.get("http://localhost:68000/grafo/", params={
     "urls": "https://www.planalto.gov.br/ccivil_03/leis/l8078.htm",
     "profundidade": 2,
     "top_n": 20
@@ -308,7 +308,7 @@ print(response.json())
 OPENAI_API_KEY=sk-your-openai-key-here
 
 # Database
-POSTGRES_CONNECTION_STRING=postgresql://user:pass@host:5432/db
+POSTGRES_CONNECTION_STRING=postgresql://user:pass@host:65432/db
 
 # Authentication
 BASIC_AUTH_USERNAME=admin
@@ -325,18 +325,18 @@ LOG_LEVEL=INFO
 version: '3.8'
 services:
   api:
-    build: ./legislatech-ai-api
+    build: ./sandoval-ai-api
     ports:
-      - "8000:8000"
+      - "68000:68000"
     environment:
-      - POSTGRES_CONNECTION_STRING=postgresql://user:pass@db:5432/legislatech
+      - POSTGRES_CONNECTION_STRING=postgresql://user:pass@db:65432/sandoval
     depends_on:
       - db
   
   db:
     image: pgvector/pgvector:pg15
     environment:
-      POSTGRES_DB: legislatech
+      POSTGRES_DB: sandoval
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass
     volumes:
@@ -388,10 +388,10 @@ A Licença MIT permite:
 
 ### Canais de Suporte
 
-- **Website**: [https://legisla.tech/ai](https://legisla.tech/ai)
-- **Email**: suporte@legisla.tech
-- **Issues**: [GitHub Issues](https://github.com/seu-usuario/legislatech-ai/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/seu-usuario/legislatech-ai/discussions)
+- **Website**: [https://sandoval.ai/ai](https://sandoval.ai/ai)
+- **Email**: suporte@sandoval.ai
+- **Issues**: [GitHub Issues](https://github.com/seu-usuario/sandoval-ai/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/seu-usuario/sandoval-ai/discussions)
 
 ### FAQ
 
@@ -409,7 +409,7 @@ A: Acesse [platform.openai.com](https://platform.openai.com) e crie uma conta.
 - **Comunidade open source** que torna projetos como este possíveis
 - **Contribuidores** que dedicam tempo e expertise
 - **Usuários** que fornecem feedback valioso
-- **Equipe Legislatech** pelo desenvolvimento contínuo
+- **AASN** pelo desenvolvimento contínuo do projeto
 
 ## 📈 Roadmap
 
@@ -429,6 +429,6 @@ A: Acesse [platform.openai.com](https://platform.openai.com) e crie uma conta.
 
 ---
 
-**Desenvolvido com ❤️ pela equipe Legislatech**
+**Desenvolvido com ❤️ pela AASN**
 
 *Transformando a forma como interagimos com a legislação brasileira através da inteligência artificial.*

--- a/legislatech-ai-api/Dockerfile
+++ b/legislatech-ai-api/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 COPY . .
-EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 68000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "68000"]

--- a/legislatech-ai-api/README.md
+++ b/legislatech-ai-api/README.md
@@ -1,4 +1,4 @@
-# Legislatech AI API
+# SANDOVAL AI API
 
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-green.svg)](https://fastapi.tiangolo.com/)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -6,7 +6,7 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13+-blue.svg)](https://www.postgresql.org/)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://www.docker.com/)
 
-> **API de inteligência artificial para busca e análise de legislação brasileira** - Desenvolvida com FastAPI e LangChain
+> **API de inteligência artificial para busca e análise de legislação brasileira** - Desenvolvida pela **AASN** com FastAPI e LangChain
 
 ## 🚀 Funcionalidades
 
@@ -45,8 +45,8 @@
 
 ### 1. Clone o repositório
 ```bash
-git clone https://github.com/seu-usuario/legislatech-ai.git
-cd legislatech-ai/legislatech-ai-api
+git clone https://github.com/seu-usuario/sandoval-ai.git
+cd sandoval-ai/sandoval-ai-api
 ```
 
 ### 2. Crie um ambiente virtual
@@ -58,8 +58,8 @@ source venv/bin/activate  # Linux/Mac
 venv\Scripts\activate  # Windows
 
 # Alternativa: Conda
-conda create -n legislatech python=3.11
-conda activate legislatech
+conda create -n sandoval python=3.11
+conda activate sandoval
 ```
 
 ### 3. Instale as dependências
@@ -82,7 +82,7 @@ Crie um arquivo `.env` na raiz do projeto:
 OPENAI_API_KEY=sk-your-openai-api-key-here
 
 # === Configurações do Banco de Dados ===
-POSTGRES_CONNECTION_STRING=postgresql://usuario:senha@localhost:5432/legislatech
+POSTGRES_CONNECTION_STRING=postgresql://usuario:senha@localhost:65432/sandoval
 
 # === Autenticação ===
 BASIC_AUTH_USERNAME=admin
@@ -134,11 +134,11 @@ brew services start postgresql
 **Docker:**
 ```bash
 docker run -d \
-  --name postgres-legislatech \
-  -e POSTGRES_DB=legislatech \
+  --name postgres-sandoval \
+  -e POSTGRES_DB=sandoval \
   -e POSTGRES_USER=usuario \
   -e POSTGRES_PASSWORD=senha \
-  -p 5432:5432 \
+  -p 65432:65432 \
   pgvector/pgvector:pg15
 ```
 
@@ -148,12 +148,12 @@ docker run -d \
 sudo -u postgres psql
 
 -- Crie o banco e usuário
-CREATE DATABASE legislatech;
+CREATE DATABASE sandoval;
 CREATE USER usuario WITH PASSWORD 'senha';
-GRANT ALL PRIVILEGES ON DATABASE legislatech TO usuario;
+GRANT ALL PRIVILEGES ON DATABASE sandoval TO usuario;
 
--- Conecte ao banco legislatech
-\c legislatech
+-- Conecte ao banco sandoval
+\c sandoval
 
 -- Instale a extensão pgvector
 CREATE EXTENSION IF NOT EXISTS vector;
@@ -193,35 +193,35 @@ except Exception as e:
 ### Desenvolvimento
 ```bash
 # Com reload automático
-uvicorn main:app --host 0.0.0.0 --port 8000 --reload --log-level debug
+uvicorn main:app --host 0.0.0.0 --port 68000 --reload --log-level debug
 
 # Com workers múltiplos
-uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
+uvicorn main:app --host 0.0.0.0 --port 68000 --workers 4
 
 # Com configurações customizadas
-uvicorn main:app --host 0.0.0.0 --port 8000 --reload --access-log --log-config log_config.json
+uvicorn main:app --host 0.0.0.0 --port 68000 --reload --access-log --log-config log_config.json
 ```
 
 ### Produção
 ```bash
 # Com Gunicorn (recomendado)
 pip install gunicorn
-gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:68000
 
 # Com Uvicorn
-uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
+uvicorn main:app --host 0.0.0.0 --port 68000 --workers 4
 ```
 
 ### Com Docker
 ```bash
 # Build da imagem
-docker build -t legislatech-ai-api .
+docker build -t sandoval-ai-api .
 
 # Execução
-docker run -p 8000:8000 --env-file .env legislatech-ai-api
+docker run -p 68000:68000 --env-file .env sandoval-ai-api
 
 # Com volumes para desenvolvimento
-docker run -p 8000:8000 --env-file .env -v $(pwd):/app legislatech-ai-api
+docker run -p 68000:68000 --env-file .env -v $(pwd):/app sandoval-ai-api
 
 # Com Docker Compose
 docker-compose up -d
@@ -230,13 +230,13 @@ docker-compose up -d
 ## 📚 Documentação da API
 
 ### Endpoints Interativos
-- **Swagger UI**: http://localhost:8000/docs
-- **ReDoc**: http://localhost:8000/redoc
-- **OpenAPI JSON**: http://localhost:8000/openapi.json
+- **Swagger UI**: http://localhost:68000/docs
+- **ReDoc**: http://localhost:68000/redoc
+- **OpenAPI JSON**: http://localhost:68000/openapi.json
 
 ### Health Check
 ```bash
-curl http://localhost:8000/health
+curl http://localhost:68000/health
 ```
 
 ## 🔗 Endpoints Disponíveis
@@ -248,7 +248,7 @@ curl http://localhost:8000/health
 
 **Exemplo de busca:**
 ```bash
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'admin:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{
@@ -273,7 +273,7 @@ curl -X POST "http://localhost:8000/v1/responses" \
 
 **Exemplo de roteamento:**
 ```bash
-curl -X POST "http://localhost:8000/v2/responses" \
+curl -X POST "http://localhost:68000/v2/responses" \
      -H "Authorization: Basic $(echo -n 'admin:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{
@@ -298,7 +298,7 @@ curl -X POST "http://localhost:8000/v2/responses" \
 
 **Exemplo de busca genérica:**
 ```bash
-curl -X POST "http://localhost:8000/v3/responses" \
+curl -X POST "http://localhost:68000/v3/responses" \
      -H "Authorization: Basic $(echo -n 'admin:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{
@@ -323,7 +323,7 @@ curl -X POST "http://localhost:8000/v3/responses" \
 
 **Exemplo de crawling:**
 ```bash
-curl -X GET "http://localhost:8000/grafo/?urls=https://www.planalto.gov.br/ccivil_03/leis/l8078.htm&profundidade=2&top_n=20"
+curl -X GET "http://localhost:68000/grafo/?urls=https://www.planalto.gov.br/ccivil_03/leis/l8078.htm&profundidade=2&top_n=20"
 ```
 
 ### Root
@@ -333,7 +333,7 @@ curl -X GET "http://localhost:8000/grafo/?urls=https://www.planalto.gov.br/ccivi
 
 **Exemplo:**
 ```bash
-curl http://localhost:8000/
+curl http://localhost:68000/
 ```
 
 ### 🔐 Autenticação
@@ -341,7 +341,7 @@ curl http://localhost:8000/
 A API utiliza autenticação HTTP Basic para endpoints sensíveis:
 
 ```bash
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'usuario:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{"input": [{"role": "user", "content": [{"type": "text", "text": "teste"}]}]}'
@@ -389,21 +389,21 @@ pytest tests/ --cov=. --cov-report=html
 #### 1. Teste de Conectividade
 ```bash
 # Health check
-curl http://localhost:8000/
+curl http://localhost:68000/
 
 # Status da API
-curl http://localhost:8000/health
+curl http://localhost:68000/health
 ```
 
 #### 2. Teste de Autenticação
 ```bash
 # Sem autenticação (deve falhar)
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Content-Type: application/json" \
      -d '{"input": [{"role": "user", "content": [{"type": "text", "text": "teste"}]}]}'
 
 # Com autenticação (deve funcionar)
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'admin:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{"input": [{"role": "user", "content": [{"type": "text", "text": "teste"}]}]}'
@@ -411,7 +411,7 @@ curl -X POST "http://localhost:8000/v1/responses" \
 
 #### 3. Teste de Busca RAG
 ```bash
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'admin:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{
@@ -431,7 +431,7 @@ curl -X POST "http://localhost:8000/v1/responses" \
 
 #### 4. Teste de Streaming
 ```bash
-curl -X POST "http://localhost:8000/v1/responses" \
+curl -X POST "http://localhost:68000/v1/responses" \
      -H "Authorization: Basic $(echo -n 'admin:senha' | base64)" \
      -H "Content-Type: application/json" \
      -d '{
@@ -453,7 +453,7 @@ curl -X POST "http://localhost:8000/v1/responses" \
 ## 📁 Estrutura do Projeto
 
 ```
-legislatech-ai-api/
+sandoval-ai-api/
 ├── main.py              # Aplicação principal FastAPI
 ├── config.py            # Configurações centralizadas
 ├── intent_router.py     # Roteamento inteligente
@@ -540,7 +540,7 @@ sudo apt install redis-server  # Ubuntu
 brew install redis            # macOS
 
 # Configure no .env
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:66379
 CACHE_TTL=3600
 ```
 
@@ -659,10 +659,10 @@ pip install -r requirements.txt --no-cache-dir
 uvicorn main:app --log-level debug
 
 # Logs do sistema
-journalctl -u legislatech-api -f
+journalctl -u sandoval-api -f
 
 # Logs do Docker
-docker logs legislatech-api -f
+docker logs sandoval-api -f
 ```
 
 #### Monitoramento de Performance
@@ -687,9 +687,9 @@ services:
   api:
     build: .
     ports:
-      - "8000:8000"
+      - "68000:68000"
     environment:
-      - POSTGRES_CONNECTION_STRING=postgresql://user:pass@db:5432/legislatech
+      - POSTGRES_CONNECTION_STRING=postgresql://user:pass@db:65432/sandoval
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - BASIC_AUTH_USERNAME=${BASIC_AUTH_USERNAME}
       - BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD}
@@ -699,7 +699,7 @@ services:
       - redis
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:68000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -707,7 +707,7 @@ services:
   db:
     image: pgvector/pgvector:pg15
     environment:
-      POSTGRES_DB: legislatech
+      POSTGRES_DB: sandoval
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass
     volumes:
@@ -715,7 +715,7 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U user -d legislatech"]
+      test: ["CMD-SHELL", "pg_isready -U user -d sandoval"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -732,8 +732,8 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "80:80"
-      - "443:443"
+      - "680:680"
+      - "6443:6443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
       - ./ssl:/etc/nginx/ssl
@@ -753,12 +753,12 @@ events {
 
 http {
     upstream api {
-        server api:8000;
+        server api:68000;
     }
 
     server {
-        listen 80;
-        server_name api.legisla.tech;
+        listen 680;
+        server_name api.sandoval.ai;
 
         location / {
             proxy_pass http://api;
@@ -774,15 +774,15 @@ http {
 ### Systemd Service
 ```ini
 [Unit]
-Description=Legislatech AI API
+Description=SANDOVAL AI API
 After=network.target
 
 [Service]
 Type=exec
-User=legislatech
-WorkingDirectory=/opt/legislatech-ai-api
-Environment=PATH=/opt/legislatech-ai-api/venv/bin
-ExecStart=/opt/legislatech-ai-api/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
+User=sandoval
+WorkingDirectory=/opt/sandoval-ai-api
+Environment=PATH=/opt/sandoval-ai-api/venv/bin
+ExecStart=/opt/sandoval-ai-api/venv/bin/uvicorn main:app --host 0.0.0.0 --port 68000 --workers 4
 Restart=always
 RestartSec=10
 
@@ -795,8 +795,8 @@ WantedBy=multi-user.target
 ### Setup de Desenvolvimento
 ```bash
 # Clone o repositório
-git clone https://github.com/seu-usuario/legislatech-ai.git
-cd legislatech-ai/legislatech-ai-api
+git clone https://github.com/seu-usuario/sandoval-ai.git
+cd sandoval-ai/sandoval-ai-api
 
 # Configure o ambiente
 python -m venv venv
@@ -808,7 +808,7 @@ pip install pre-commit
 pre-commit install
 
 # Configure o banco de teste
-createdb legislatech_test
+createdb sandoval_test
 ```
 
 ### Diretrizes de Código
@@ -831,10 +831,10 @@ Este projeto está sob a licença MIT. Veja o arquivo [LICENSE](../LICENSE) para
 ## 🆘 Suporte
 
 ### Canais de Ajuda
-- **Documentação**: [docs.legisla.tech](https://docs.legisla.tech)
-- **Email**: suporte@legisla.tech
-- **Issues**: [GitHub Issues](https://github.com/seu-usuario/legislatech-ai/issues)
-- **Discord**: [Comunidade Legislatech](https://discord.gg/legislatech)
+- **Documentação**: [docs.sandoval.ai](https://docs.sandoval.ai)
+- **Email**: suporte@sandoval.ai
+- **Issues**: [GitHub Issues](https://github.com/seu-usuario/sandoval-ai/issues)
+- **Discord**: [Comunidade SANDOVAL](https://discord.gg/sandoval)
 
 ### FAQ
 
@@ -849,6 +849,6 @@ A: Use load balancer, múltiplas instâncias e banco de dados replicado.
 
 ---
 
-**Desenvolvido com ❤️ pela equipe Legislatech**
+**Desenvolvido com ❤️ pela AASN**
 
 *Transformando a pesquisa jurídica através da inteligência artificial.*

--- a/legislatech-ai-api/main.py
+++ b/legislatech-ai-api/main.py
@@ -6,8 +6,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from routes import v1, v2, v3, grafo
 
 app = FastAPI(
-    title="RAG & Search API",
-    description="API com endpoints para busca RAG, busca híbrida e crawling de grafos.",
+    title="SANDOVAL AI - RAG & Search API",
+    description="API da SANDOVAL AI, desenvolvida pela AASN, com endpoints para busca RAG, busca híbrida e crawling de grafos.",
     version="1.0.0"
 )
 
@@ -28,4 +28,4 @@ app.include_router(grafo.router, prefix="/grafo", tags=["Grafo Crawler"])
 
 @app.get("/", tags=["Root"])
 def root():
-    return {"message": "Bem-vindo à API de RAG Search + Completion"}
+    return {"message": "Bem-vindo à SANDOVAL AI, desenvolvida pela AASN, para experiências avançadas de RAG Search."}

--- a/legislatech-ai-crawlers/README.md
+++ b/legislatech-ai-crawlers/README.md
@@ -1,4 +1,4 @@
-# Legislatech AI Crawlers
+# SANDOVAL AI Crawlers
 
 [![Python](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Playwright](https://img.shields.io/badge/Playwright-Automation-green.svg)](https://playwright.dev/)
@@ -6,11 +6,11 @@
 [![Spacy](https://img.shields.io/badge/Spacy-NLP-purple.svg)](https://spacy.io/)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue.svg)](https://www.docker.com/)
 
-> **Sistema de crawlers especializados para coleta automatizada de legislação brasileira** - Desenvolvido com Playwright, BeautifulSoup e IA
+> **Sistema de crawlers especializados para coleta automatizada de legislação brasileira** - Desenvolvido pela **AASN** com Playwright, BeautifulSoup e IA
 
 ## 🚀 Sobre o Projeto
 
-O **Legislatech AI Crawlers** é um sistema modular de web scraping especializado na coleta automatizada de legislação brasileira. Utilizando tecnologias avançadas de automação web e processamento de linguagem natural, extraímos, processamos e estruturamos dados legislativos de fontes oficiais.
+O **SANDOVAL AI Crawlers** é um sistema modular de web scraping especializado na coleta automatizada de legislação brasileira. Utilizando tecnologias avançadas de automação web e processamento de linguagem natural, extraímos, processamos e estruturamos dados legislativos de fontes oficiais.
 
 ### 🎯 Objetivos
 
@@ -56,13 +56,13 @@ O **Legislatech AI Crawlers** é um sistema modular de web scraping especializad
 
 ## 🏗️ Arquitetura
 
-### Visão Geral do Sistema Legislatech AI
+### Visão Geral do Sistema SANDOVAL AI
 
-O **Legislatech AI** é um ecossistema completo de inteligência artificial para análise de legislação brasileira, composto por três módulos principais:
+O **SANDOVAL AI** é um ecossistema completo de inteligência artificial para análise de legislação brasileira, composto por três módulos principais:
 
 ```
-legislatech-ai/
-├── legislatech-ai-api/           # API REST com FastAPI
+sandoval-ai/
+├── sandoval-ai-api/           # API REST com FastAPI
 │   ├── routes/                  # Endpoints organizados por versão
 │   │   ├── v1.py               # RAG Search com reranking
 │   │   ├── v2.py               # Intent Router
@@ -78,7 +78,7 @@ legislatech-ai/
 │   ├── requirements.txt        # Dependências Python
 │   ├── Dockerfile             # Containerização
 │   └── README.md              # Documentação da API
-├── legislatech-ai-crawlers/     # Sistema de Crawlers
+├── sandoval-ai-crawlers/     # Sistema de Crawlers
 │   ├── leis-ordinarias/        # Crawler de Leis Ordinárias
 │   ├── decretos-emendas/       # Crawler de Decretos e Emendas
 │   ├── medidas-provisorias/    # Crawler de Medidas Provisórias
@@ -237,8 +237,8 @@ Os crawlers alimentam a API através de:
 
 ### 1. Clone o repositório
 ```bash
-git clone https://github.com/seu-usuario/legislatech-ai.git
-cd legislatech-ai/legislatech-ai-crawlers
+git clone https://github.com/seu-usuario/sandoval-ai.git
+cd sandoval-ai/sandoval-ai-crawlers
 ```
 
 ### 2. Configure o ambiente
@@ -260,7 +260,7 @@ Crie um arquivo `.env` em cada crawler:
 OPENAI_API_KEY=sk-your-openai-api-key-here
 
 # === Configurações do Banco de Dados ===
-DATABASE_URL=postgresql://usuario:senha@localhost:5432/legislatech
+DATABASE_URL=postgresql://usuario:senha@localhost:65432/sandoval
 
 # === Configurações do Crawler ===
 WORKERS=10
@@ -318,12 +318,12 @@ python main.py
 #### Build da imagem
 ```bash
 cd leis-ordinarias
-docker build -t legislatech-crawler-leis .
+docker build -t sandoval-crawler-leis .
 ```
 
 #### Execução
 ```bash
-docker run --env-file .env legislatech-crawler-leis
+docker run --env-file .env sandoval-crawler-leis
 ```
 
 ### Execução Paralela
@@ -612,9 +612,9 @@ services:
 ### Agendamento com Cron
 ```bash
 # Adicione ao crontab
-0 2 * * * cd /path/to/legislatech-ai-crawlers/leis-ordinarias && python main.py
-0 3 * * * cd /path/to/legislatech-ai-crawlers/decretos-emendas && python main.py
-0 4 * * * cd /path/to/legislatech-ai-crawlers/medidas-provisorias && python main.py
+0 2 * * * cd /path/to/sandoval-ai-crawlers/leis-ordinarias && python main.py
+0 3 * * * cd /path/to/sandoval-ai-crawlers/decretos-emendas && python main.py
+0 4 * * * cd /path/to/sandoval-ai-crawlers/medidas-provisorias && python main.py
 ```
 
 ### Monitoramento
@@ -691,10 +691,10 @@ Este projeto está sob a licença MIT. Veja o arquivo [LICENSE](../LICENSE) para
 ## 🆘 Suporte
 
 ### Canais de Ajuda
-- **Documentação**: [docs.legisla.tech/crawlers](https://docs.legisla.tech/crawlers)
-- **Email**: suporte@legisla.tech
-- **Issues**: [GitHub Issues](https://github.com/seu-usuario/legislatech-ai/issues)
-- **Discord**: [Comunidade Legislatech](https://discord.gg/legislatech)
+- **Documentação**: [docs.sandoval.ai/crawlers](https://docs.sandoval.ai/crawlers)
+- **Email**: suporte@sandoval.ai
+- **Issues**: [GitHub Issues](https://github.com/seu-usuario/sandoval-ai/issues)
+- **Discord**: [Comunidade SANDOVAL](https://discord.gg/sandoval)
 
 ### FAQ
 
@@ -712,7 +712,7 @@ A: Configure agendamento automático com cron ou Docker.
 
 ---
 
-**Desenvolvido com ❤️ pela equipe Legislatech**
+**Desenvolvido com ❤️ pela AASN**
 
 *Automatizando a coleta de legislação brasileira com inteligência artificial.*
 
@@ -720,7 +720,7 @@ A: Configure agendamento automático com cron ou Docker.
 
 ```python
 # Análise de grafo de uma lei específica
-response = requests.get("http://localhost:8000/grafo/", params={
+response = requests.get("http://localhost:68000/grafo/", params={
     "urls": "https://www.planalto.gov.br/ccivil_03/leis/l8078.htm",
     "profundidade": 2,
     "top_n": 20


### PR DESCRIPTION
## Summary
- rebrand the documentation to refer to the platform as SANDOVAL AI and credit AASN
- update all setup instructions and examples to use ports prefixed with 6, including Docker and Nginx snippets
- adjust the FastAPI metadata and Dockerfile to reflect the new branding and port configuration

## Testing
- not run (documentation and configuration updates only)

------
https://chatgpt.com/codex/tasks/task_e_68cd46f6436c832bab491db96b545e57